### PR TITLE
Translator: Internal improvements

### DIFF
--- a/src/Charcoal/Translator/ServiceProvider/TranslatorServiceProvider.php
+++ b/src/Charcoal/Translator/ServiceProvider/TranslatorServiceProvider.php
@@ -19,6 +19,7 @@ use Symfony\Component\Translation\Loader\QtFileLoader;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\Loader\JsonFileLoader;
 use Symfony\Component\Translation\Loader\YamlFileLoader;
+use Symfony\Component\Translation\MessageSelector;
 
 // From `charcoal-translator`
 use Charcoal\Translator\LocalesConfig;
@@ -168,7 +169,7 @@ class TranslatorServiceProvider implements ServiceProviderInterface
          * @return MessageSelector
          */
         $container['translator/message-selector'] = function () {
-            return null;
+            return new MessageSelector();
         };
 
         /**


### PR DESCRIPTION
In order to properly support (and fix) _choice messages_, we need access to the message selector. Unfortunately, the [selector is private](https://github.com/symfony/translation/blob/v3.3.2/Translator.php#L57) under Symfony's `Translator` class.
To circumvent this limitation, we need to define our own selector property and require from the constructor.

Changes:
- Added protected getter for the `LocalesManager` (for subclasses)
- Added setter/getter for the `MessageSelector`
- Added Symfony's `MessageSelector` to the service provider
- Updated `Translator` to use the manager's getter
- Changed visibility to protected for `isValidTranslation()` (for subclasses)
- Fixed choice message in `translateChoice()` and `translationChoice()`

Note: Unit tests are already completed but will be featured in a future commit, after this is merged.