### PR TITLE
Fix & Improve Locales

### DIFF
--- a/tests/Charcoal/Translator/LocalesManagerTest.php
+++ b/tests/Charcoal/Translator/LocalesManagerTest.php
@@ -48,6 +48,7 @@ class LocalesManagerTest extends PHPUnit_Framework_TestCase
             'default_language' => 'bar'
         ]);
         $this->assertEquals('bar', $this->obj->currentLocale());
+        $this->assertEquals('bar', $this->obj->defaultLocale());
     }
 
     public function testConstructorDefaultLanguageWithInvalidType()


### PR DESCRIPTION
Changes:
- Improve internals of `LocalesManager`
  - Renamed class properties `$defaultLocale` and `$currentLocale` to streamline use of "locale" vs "language"
  - Added private `setDefaultLocale()` method to cleanup class constructor
  - Added public `defaultLocale()` method
  - Changed `hasLocale()` to use `isset()` instead of `in_array()`
  - Changed `setLocales()` to build the `$languages` class property
  - Changed 'locales/available-languages' and 'locales/languages' to fetch values from `LocalesManager`
- Fix 'locales/browser-language'
  - Filtered inactive languages from raw locales defined in 'locales/config'