### PR TITLE
Add TranslationFactory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.3.x-dev"
+            "dev-master": "0.4.x-dev"
         }
     },
     "require": {

--- a/src/Charcoal/Translator/Factory/TranslationFactory.php
+++ b/src/Charcoal/Translator/Factory/TranslationFactory.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Charcoal\Translator\Factory;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+// From 'symfony/translation'
+use Symfony\Component\Translation\Formatter\MessageFormatter;
+use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
+
+// From 'charcoal-translator'
+use Charcoal\Translator\LocalesManager;
+use Charcoal\Translator\Translation;
+
+/**
+ * Class that creates translation objects.
+ *
+ * The translation factory is an alternative to the Translator for creating Translation objects
+ * without passing messages through the catalogues where a message might be accidentally translated.
+ *
+ * A note about Translation objects:
+ *
+ * - If a string is given, that value is assigned to the current locale.
+ * - If an array is given, it is interpreted as a language-map whose keys are language codes
+ * and whose values are localized strings.
+ */
+class TranslationFactory implements TranslationFactoryInterface
+{
+    /**
+     * @var LocalesManager
+     */
+    private $manager;
+
+    /**
+     * @var MessageFormatterInterface
+     */
+    private $formatter;
+
+    /**
+     * The class to use for language-maps.
+     *
+     * @var string
+     */
+    protected $translationClass = Translation::class;
+
+    /**
+     * @param array $data Factory dependencies.
+     */
+    public function __construct(array $data)
+    {
+        $this->setManager($data['manager']);
+
+        // Ensure Charcoal has control of the message formatter.
+        if (!isset($data['message_formatter'])) {
+            $data['message_formatter'] = new MessageFormatter();
+        }
+        $this->setFormatter($data['message_formatter']);
+    }
+
+    /**
+     * Create a new Translation object from a (mixed) message.
+     *
+     * @param  mixed $value      A string or language-map.
+     * @param  array $parameters An array of parameters for the message.
+     * @return Translation|null  A new Translation object or NULL if the value is not acceptable.
+     */
+    public function createTranslationFormatted($value, array $parameters = [])
+    {
+        if ($this->isValidTranslation($value) === false) {
+            return null;
+        }
+
+        $translation = $this->createTranslation($value);
+
+        if (!empty($parameters)) {
+            $translation->each(function ($message, $locale) use ($parameters) {
+                return $this->getFormatter()->format($message, $locale, $parameters);
+            });
+        }
+
+        return $translation;
+    }
+
+    /**
+     * Create a new Translation object from a (mixed) message by choosing a translation according to a number.
+     *
+     * @param  mixed   $value      A string or language-map.
+     * @param  integer $number     The number to use to find the indice of the message.
+     * @param  array   $parameters An array of parameters for the message.
+     * @return Translation|null A new Translation object or NULL if the value is not acceptable.
+     */
+    public function createTranslationChoice($value, $number, array $parameters = [])
+    {
+        if ($this->isValidTranslation($value) === false) {
+            return null;
+        }
+
+        $translation = $this->createTranslation($value);
+        $translation->each(function ($message, $locale) use ($number, $parameters) {
+            return $this->getFormatter()->choiceFormat($message, $number, $locale, $parameters);
+        });
+
+        return $translation;
+    }
+
+    /**
+     * Create a new Translation object that is empty or from a (mixed) message.
+     *
+     * @param  mixed $value A string or language-map.
+     * @throws RuntimeException If the class name is not a string.
+     * @return Translation A new Translation object.
+     */
+    public function createTranslation($value = null)
+    {
+        $transClass = $this->getTranslationClass();
+
+        if (class_exists($transClass)) {
+            return new $transClass($value, $this->getManager());
+        }
+
+        throw new RuntimeException(sprintf(
+            'Translation class (%s) could not be instantiated',
+            $transClass
+        ));
+    }
+
+    /**
+     * Determine if the value is translatable.
+     *
+     * @param  mixed $value The value to be checked.
+     * @return boolean
+     */
+    public function isValidTranslation($value)
+    {
+        if (empty($value) && !is_numeric($value)) {
+            return false;
+        }
+
+        if (is_string($value)) {
+            return !empty(trim($value));
+        }
+
+        if ($value instanceof Translation) {
+            return true;
+        }
+
+        if (is_array($value)) {
+            return !!array_filter(
+                $value,
+                function ($v, $k) {
+                    if (is_string($k) && strlen($k) > 0) {
+                        if (is_string($v) && strlen($v) > 0) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                },
+                ARRAY_FILTER_USE_BOTH
+            );
+        }
+        return false;
+    }
+
+    /**
+     * Set the locales manager.
+     *
+     * @param  LocalesManager $manager The locales manager.
+     * @return void
+     */
+    private function setManager(LocalesManager $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    /**
+     * Retrieve the locales manager.
+     *
+     * @return LocalesManager
+     */
+    protected function getManager()
+    {
+        return $this->manager;
+    }
+
+    /**
+     * Set the message formatter.
+     *
+     * The {@see SymfonyTranslator} keeps the message formatter private (as of 3.3.2),
+     * thus we must explicitly require it in this class to guarantee access.
+     *
+     * @param  MessageFormatterInterface $formatter The formatter.
+     * @return void
+     */
+    private function setFormatter(MessageFormatterInterface $formatter)
+    {
+        $this->formatter = $formatter;
+    }
+
+    /**
+     * Retrieve the message formatter.
+     *
+     * @return MessageFormatterInterface
+     */
+    public function getFormatter()
+    {
+        return $this->formatter;
+    }
+
+    /**
+     * Set the class name of the Translation object.
+     *
+     * @param  string $className The class name of the translation.
+     * @throws InvalidArgumentException If the class name is not a string.
+     * @return self
+     */
+    public function setTranslationClass($className)
+    {
+        if (!is_string($className)) {
+            throw new InvalidArgumentException(
+                'Translation class name must be a string'
+            );
+        }
+
+        $this->translationClass = $className;
+        return $this;
+    }
+
+    /**
+     * Retrieve the class name of the Translation object.
+     *
+     * @return string
+     */
+    public function getTranslationClass()
+    {
+        return $this->translationClass;
+    }
+}

--- a/src/Charcoal/Translator/Factory/TranslationFactoryAwareTrait.php
+++ b/src/Charcoal/Translator/Factory/TranslationFactoryAwareTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Charcoal\Translator\Factory;
+
+use RuntimeException;
+
+// From 'charcoal-translator'
+use Charcoal\Translator\Factory\TranslationFactoryInterface;
+
+/**
+ * Provides translation factory features.
+ */
+trait TranslationFactoryAwareTrait
+{
+    /**
+     * Store the factory instance.
+     *
+     * @var TranslationFactoryInterface
+     */
+    private $translationFactory;
+
+    /**
+     * Set a translation factory.
+     *
+     * @param  TranslationFactoryInterface $factory The factory to create translations.
+     * @return void
+     */
+    protected function setTranslationFactory(TranslationFactoryInterface $factory)
+    {
+        $this->translationFactory = $factory;
+    }
+
+    /**
+     * Retrieve the translation factory.
+     *
+     * @throws RuntimeException If the translation factory is missing.
+     * @return TranslationFactoryInterface
+     */
+    public function getTranslationFactory()
+    {
+        if (!isset($this->translationFactory)) {
+            throw new RuntimeException(sprintf(
+                'Translation Factory is not defined for [%s]',
+                get_class($this)
+            ));
+        }
+
+        return $this->translationFactory;
+    }
+}

--- a/src/Charcoal/Translator/Factory/TranslationFactoryInterface.php
+++ b/src/Charcoal/Translator/Factory/TranslationFactoryInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Charcoal\Translator\Factory;
+
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
+/**
+ * Translation factory interface.
+ */
+interface TranslationFactoryInterface
+{
+    /**
+     * Create a new Translation object from a (mixed) message.
+     *
+     * @param  mixed $value      A string or language-map.
+     * @param  array $parameters An array of parameters for the message.
+     * @return Translation|null  A new Translation object or NULL if the value is not acceptable.
+     */
+    public function createTranslationFormatted($value, array $parameters = []);
+
+    /**
+     * Create a new Translation object from a (mixed) message by choosing a translation according to a number.
+     *
+     * @param  mixed   $value      A string or language-map.
+     * @param  integer $number     The number to use to find the indice of the message.
+     * @param  array   $parameters An array of parameters for the message.
+     * @return Translation|null A new Translation object or NULL if the value is not acceptable.
+     */
+    public function createTranslationChoice($value, $number, array $parameters = []);
+
+    /**
+     * Create a new Translation object that is empty or from a (mixed) message.
+     *
+     * @param  mixed $value A string or language-map.
+     * @return Translation A new Translation object.
+     */
+    public function createTranslation($value = null);
+}

--- a/src/Charcoal/Translator/Middleware/LanguageMiddleware.php
+++ b/src/Charcoal/Translator/Middleware/LanguageMiddleware.php
@@ -142,7 +142,7 @@ class LanguageMiddleware
             'use_host'         => false,
             'host_map'         => [],
 
-            'set_locale'       => true
+            'set_locale'       => true,
         ];
     }
 

--- a/src/Charcoal/Translator/Script/TranslationParserScript.php
+++ b/src/Charcoal/Translator/Script/TranslationParserScript.php
@@ -101,42 +101,42 @@ class TranslationParserScript extends AdminScript
                 'prefix'       => 'o',
                 'longPrefix'   => 'output',
                 'description'  => 'Output file path. Make sure the path exists in the translator paths definition. (Default: translation/)',
-                'defaultValue' => 'translations/'
+                'defaultValue' => 'translations/',
             ],
             'domain' => [
                 'prefix'       => 'd',
                 'longPrefix'   => 'domain',
                 'description'  => 'Doman for the csv file. Based on symfony/translator CsvLoader.',
-                'defaultValue' => 'messages'
+                'defaultValue' => 'messages',
             ],
             'recursive' => [
                 'prefix'       => 'r',
                 'longPrefix'   => 'recursive-level',
                 'description'  => 'Max recursive level for the glob operation on folders.',
-                'defaultValue' => -1
+                'defaultValue' => -1,
             ],
             'path' => [
                 'prefix'       => 'p',
                 'longPrefix'   => 'path',
                 'description'  => 'Path relative to the project installation (ex: templates/*/*/)',
-                'defaultValue' => false
+                'defaultValue' => false,
             ],
             'type' => [
                 'prefix'       => 't',
                 'longPrefix'   => 'type',
                 'description'  => 'File type (mustache || php)',
-                'defaultValue' => 'mustache'
+                'defaultValue' => 'mustache',
             ],
             'php_function' => [
                 'longPrefix'   => 'php',
                 'description'  => 'Php function to be parsed.',
-                'defaultValue' => 'translate'
+                'defaultValue' => 'translate',
             ],
             'mustache_tag' => [
                 'longPrefix'   => 'mustache',
                 'description'  => 'Mustache function to be parsed.',
-                'defaultValue' => '_t'
-            ]
+                'defaultValue' => '_t',
+            ],
         ];
 
         $arguments = array_merge(parent::defaultArguments(), $arguments);
@@ -464,7 +464,7 @@ class TranslationParserScript extends AdminScript
         if (!$this->fileTypes) {
             $this->fileTypes = [
                 'php',
-                'mustache'
+                'mustache',
             ];
         }
         return $this->fileTypes;

--- a/src/Charcoal/Translator/ServiceProvider/TranslatorServiceProvider.php
+++ b/src/Charcoal/Translator/ServiceProvider/TranslatorServiceProvider.php
@@ -27,6 +27,7 @@ use Charcoal\Translator\LocalesConfig;
 use Charcoal\Translator\LocalesManager;
 use Charcoal\Translator\Translator;
 use Charcoal\Translator\TranslatorConfig;
+use Charcoal\Translator\Factory\TranslationFactory;
 use Charcoal\Translator\Middleware\LanguageMiddleware;
 
 /**
@@ -230,11 +231,10 @@ class TranslatorServiceProvider implements ServiceProviderInterface
         $container['translator'] = function (Container $container) {
             $transConfig = $container['translator/config'];
             $translator  = new Translator([
-                'manager'           => $container['locales/manager'],
-                'message_selector'  => $container['translator/message-selector'],
-                'message_formatter' => $container['translator/message-formatter'],
-                'cache_dir'         => $transConfig['cache_dir'],
-                'debug'             => $transConfig['debug'],
+                'manager'             => $container['locales/manager'],
+                'translation_factory' => $container['translation/factory'],
+                'cache_dir'           => $transConfig['cache_dir'],
+                'debug'               => $transConfig['debug'],
             ]);
 
             $translator->setFallbackLocales($container['locales/fallback-languages']);
@@ -274,6 +274,20 @@ class TranslatorServiceProvider implements ServiceProviderInterface
             }
 
             return $translator;
+        };
+
+        /**
+         * Translation object factory.
+         *
+         * @param  Container $container Pimple DI container.
+         * @return TranslationFactory
+         */
+        $container['translation/factory'] = function (Container $container) {
+            $factory = new TranslationFactory([
+                'manager'           => $container['locales/manager'],
+                'message_formatter' => $container['translator/message-formatter'],
+            ]);
+            return $factory;
         };
 
         $this->registerTranslatorLoaders($container);

--- a/src/Charcoal/Translator/Translation.php
+++ b/src/Charcoal/Translator/Translation.php
@@ -11,9 +11,15 @@ use JsonSerializable;
 use Charcoal\Translator\LocalesManager;
 
 /**
- * A translation object holds a localized message in all available locales.
+ * Translation Bag
  *
- * Available locales is provided with a locales manager.
+ * A Translation object is a language map whose keys must be strings representing
+ * language codes and the values must be any of the following types:
+ * null, string, or an array of zero or more of the previous possibilities.
+ *
+ * The available language codes are provided by a locales manager that is required
+ * by the Translation object. Its main function is to provide whichever language code
+ * is the current environment's locale.
  */
 class Translation implements
     ArrayAccess,
@@ -107,7 +113,7 @@ class Translation implements
 
         if (!isset($this->val[$lang])) {
             throw new DomainException(sprintf(
-                'Translation for "%s" is not defined.',
+                'Translation for "%s" is not defined',
                 $lang
             ));
         }
@@ -236,7 +242,7 @@ class Translation implements
             $this->val[$lang] = $val;
         } else {
             throw new InvalidArgumentException(
-                'Invalid localized value.'
+                'Invalid localized value'
             );
         }
 

--- a/src/Charcoal/Translator/Translation.php
+++ b/src/Charcoal/Translator/Translation.php
@@ -34,13 +34,16 @@ class Translation implements
     private $manager;
 
     /**
-     * @param Translation|array|string $val     The translation values.
-     * @param LocalesManager           $manager A LocalesManager instance.
+     * @param mixed          $val     The {@see self::setVal() translation value(s)}.
+     * @param LocalesManager $manager A LocalesManager instance.
      */
     public function __construct($val, LocalesManager $manager)
     {
         $this->manager = $manager;
-        $this->setVal($val);
+
+        if ($val !== null) {
+            $this->setVal($val);
+        }
     }
 
     /**

--- a/tests/Charcoal/Translator/ContainerProvider.php
+++ b/tests/Charcoal/Translator/ContainerProvider.php
@@ -134,33 +134,33 @@ class ContainerProvider
                 'locales'   => [
                     'languages' => [
                         'en' => [ 'locale' => 'en-US', 'locales' => [ 'en_US.UTF-8', 'en_US.utf8', 'en_US' ] ],
-                        'fr' => [ 'locale' => 'fr-FR' ]
+                        'fr' => [ 'locale' => 'fr-FR' ],
                     ],
                     'default_language'   => 'en',
-                    'fallback_languages' => [ 'en' ]
+                    'fallback_languages' => [ 'en' ],
                 ],
                 'translator' => [
                     'paths' => [
-                        '/Charcoal/Translator/Fixture/translations'
+                        '/Charcoal/Translator/Fixture/translations',
                     ],
                     'translations' => [
                         'messages' => [
                             'en' => [
-                                'foo' => 'FOO'
+                                'foo' => 'FOO',
                             ],
                             'fr' => [
-                                'foo' => 'OOF'
-                            ]
-                        ]
+                                'foo' => 'OOF',
+                            ],
+                        ],
                     ],
                     'auto_detect' => true,
-                    'debug' => false
+                    'debug' => false,
                 ],
                 'view' => [
                     'paths' => [
-                        '/Charcoal/Translator/Fixture/views'
-                    ]
-                ]
+                        '/Charcoal/Translator/Fixture/views',
+                    ],
+                ],
             ]);
         };
     }
@@ -224,7 +224,7 @@ class ContainerProvider
             return new LocalesManager([
                 'locales'            => $container['locales/config']['languages'],
                 'default_language'   => $container['locales/config']['default_language'],
-                'fallback_languages' => $container['locales/config']['fallback_languages']
+                'fallback_languages' => $container['locales/config']['fallback_languages'],
             ]);
         };
 
@@ -237,7 +237,7 @@ class ContainerProvider
                 'manager'          => $container['locales/manager'],
                 'message_selector' => new MessageSelector(),
                 'cache_dir'        => null,
-                'debug'            => $container['translator/config']['debug']
+                'debug'            => $container['translator/config']['debug'],
             ]);
 
             $translator->setFallbackLocales($container['locales/config']['fallback_languages']);
@@ -261,8 +261,8 @@ class ContainerProvider
                 'base_path' => $container['config']['base_path'],
                 'paths'     => [
                     'metadata',
-                    'vendor/locomotivemtl/charcoal-property/metadata'
-                ]
+                    'vendor/locomotivemtl/charcoal-property/metadata',
+                ],
             ]);
         };
     }
@@ -280,11 +280,13 @@ class ContainerProvider
                 'map' => [
                     'database' => DatabaseSource::class
                 ],
-                'arguments'  => [[
-                    'logger' => $container['logger'],
-                    'cache'  => $container['cache'],
-                    'pdo'    => $container['database']
-                ]]
+                'arguments'  => [
+                    [
+                        'logger' => $container['logger'],
+                        'cache'  => $container['cache'],
+                        'pdo'    => $container['database'],
+                    ],
+                ],
             ]);
         };
     }
@@ -299,13 +301,15 @@ class ContainerProvider
     {
         $container['model/factory'] = function (Container $container) {
             return new Factory([
-                'arguments' => [[
-                    'container'         => $container,
-                    'logger'            => $container['logger'],
-                    'metadata_loader'   => $container['metadata/loader'],
-                    'source_factory'    => $container['source/factory'],
-                    'property_factory'  => $container['property/factory']
-                ]]
+                'arguments' => [
+                    [
+                        'container'         => $container,
+                        'logger'            => $container['logger'],
+                        'metadata_loader'   => $container['metadata/loader'],
+                        'source_factory'    => $container['source/factory'],
+                        'property_factory'  => $container['property/factory'],
+                    ],
+                ],
             ]);
         };
     }
@@ -322,14 +326,16 @@ class ContainerProvider
             return new Factory([
                 'resolver_options' => [
                     'prefix' => '\\Charcoal\\Property\\',
-                    'suffix' => 'Property'
+                    'suffix' => 'Property',
                 ],
-                'arguments' => [[
-                    'container'  => $container,
-                    'database'   => $container['database'],
-                    'logger'     => $container['logger'],
-                    'translator' => $container['translator']
-                ]]
+                'arguments' => [
+                    [
+                        'container'  => $container,
+                        'database'   => $container['database'],
+                        'logger'     => $container['logger'],
+                        'translator' => $container['translator'],
+                    ],
+                ],
             ]);
         };
     }

--- a/tests/Charcoal/Translator/Factory/TranslationFactoryAwareTraitTest.php
+++ b/tests/Charcoal/Translator/Factory/TranslationFactoryAwareTraitTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Charcoal\Tests\Translator\Factory;
+
+use RuntimeException;
+use ReflectionClass;
+
+// From 'charcoal-translator'
+use Charcoal\Translator\Factory\TranslationFactoryAwareTrait;
+use Charcoal\Translator\Factory\TranslationFactory;
+use Charcoal\Tests\AbstractTestCase;
+
+/**
+ *
+ */
+class TranslationFactoryAwareTraitTest extends AbstractTestCase
+{
+    /**
+     * Tested Class.
+     *
+     * @var TranslationFactoryAwareTrait
+     */
+    private $obj;
+
+    /**
+     * Set up the test.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->obj = $this->getMockForTrait(TranslationFactoryAwareTrait::class);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     *
+     * @return void
+     */
+    public function testTranslatorWithoutSettingThrowsException()
+    {
+        $this->obj->getTranslationFactory();
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetTranslator()
+    {
+        $factory = $this->getMockBuilder(TranslationFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->callMethod($this->obj, 'setTranslationFactory', [ $factory ]);
+        $this->assertEquals($factory, $this->obj->getTranslationFactory());
+    }
+}

--- a/tests/Charcoal/Translator/Factory/TranslationFactoryTest.php
+++ b/tests/Charcoal/Translator/Factory/TranslationFactoryTest.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Charcoal\Tests\Translator\Factory;
+
+use ReflectionClass;
+
+// From 'symfony/translation'
+use Symfony\Component\Translation\Formatter\MessageFormatter;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+
+// From 'charcoal-translator'
+use Charcoal\Translator\Factory\TranslationFactory;
+use Charcoal\Translator\Factory\TranslationFactoryInterface;
+use Charcoal\Translator\LocalesManager;
+use Charcoal\Translator\Translation;
+use Charcoal\Tests\AbstractTestCase;
+use Charcoal\Tests\Translator\Mock\StringClass;
+
+/**
+ *
+ */
+class TranslationFactoryTest extends AbstractTestCase
+{
+    /**
+     * Tested Class.
+     *
+     * @var TranslationFactory
+     */
+    private $obj;
+
+    /**
+     * The language manager.
+     *
+     * @var LocalesManager
+     */
+    private $localesManager;
+
+    /**
+     * Set up the test.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->obj = new TranslationFactory([
+            'manager' => $this->localesManager(),
+        ]);
+    }
+
+    /**
+     * @return LocalesManager
+     */
+    private function localesManager()
+    {
+        if ($this->localesManager === null) {
+            $this->localesManager = new LocalesManager([
+                'locales' => [
+                    'en' => [
+                        'locale' => 'en_US.UTF8',
+                    ],
+                    'fr' => [
+                        'locale' => 'fr_FR.UTF8',
+                    ],
+                ],
+                'default_language'   => 'en',
+                'fallback_languages' => [ 'en' ],
+            ]);
+        }
+
+        return $this->localesManager;
+    }
+
+    /**
+     * @return void
+     */
+    public function testConstructorWithMessageFormatter()
+    {
+        $formatter = new MessageFormatter();
+        $factory   = new TranslationFactory([
+            'manager'           => $this->localesManager(),
+            'message_formatter' => $formatter,
+        ]);
+
+        $this->assertSame($formatter, $factory->getFormatter());
+    }
+
+    /**
+     * @return void
+     */
+    public function testConstructorWithoutMessageFormatter()
+    {
+        $factory = new TranslationFactory([
+            'manager'           => $this->localesManager(),
+            'message_formatter' => null,
+        ]);
+
+        $this->assertInstanceOf(MessageFormatter::class, $factory->getFormatter());
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateTranslationFormatted()
+    {
+        $ret = $this->obj->createTranslationFormatted('Hello!');
+        $this->assertInstanceOf(Translation::class, $ret);
+        $this->assertEquals('Hello!', (string)$ret);
+
+        $translation = clone($ret);
+        $ret = $this->obj->createTranslationFormatted($translation);
+        $this->assertInstanceOf(Translation::class, $ret);
+        $this->assertEquals('Hello!', (string)$ret);
+
+        $ret = $this->obj->createTranslationFormatted([
+            'en' => 'Hello!',
+            'fr' => 'Bonjour!',
+        ]);
+        $this->assertInstanceOf(Translation::class, $ret);
+        $this->assertEquals('Hello!', (string)$ret);
+
+        $ret = $this->obj->createTranslationFormatted([
+            'en' => 'Charcoal is %what%!',
+            'fr' => 'Charcoal est %what% !',
+        ], [
+            '%what%' => 'xyzzy',
+        ]);
+        $this->assertInstanceOf(Translation::class, $ret);
+        $this->assertEquals('Charcoal is xyzzy!', $ret['en']);
+        $this->assertEquals('Charcoal est xyzzy !', $ret['fr']);
+    }
+
+    /**
+     * @dataProvider invalidTransTests
+     *
+     * @param  mixed $val The message ID.
+     * @return void
+     */
+    public function testCreateTranslationInvalidValuesReturnNull($val)
+    {
+        $this->assertNull($this->obj->createTranslationFormatted($val));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateTranslationChoice()
+    {
+        $ret = $this->obj->createTranslationChoice('There is one apple|There is %count% apples', 2);
+        $this->assertInstanceOf(Translation::class, $ret);
+        $this->assertEquals('There is 2 apples', (string)$ret);
+
+        $translation = clone($ret);
+        $ret = $this->obj->createTranslationChoice($translation, 2);
+        $this->assertInstanceOf(Translation::class, $ret);
+        $this->assertEquals('There is 2 apples', (string)$ret);
+
+        $ret = $this->obj->createTranslationChoice([
+            'en' => 'There is one apple|There is %count% apples',
+            'fr' => 'Il y a %count% pomme|Il y a %count% pommes',
+        ], 1);
+        $this->assertInstanceOf(Translation::class, $ret);
+        $this->assertEquals('There is one apple', (string)$ret);
+    }
+
+    /**
+     * @dataProvider invalidTransTests
+     *
+     * @param  mixed $val The message ID.
+     * @return void
+     */
+    public function testCreateTranslationChoiceInvalidValuesReturnNull($val)
+    {
+        $this->assertNull($this->obj->createTranslationChoice($val, 1));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateTranslation()
+    {
+        $ret = $this->obj->createTranslation();
+        $this->assertInstanceOf(Translation::class, $ret);
+        $this->assertEquals('', (string)$ret);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     *
+     * @return void
+     */
+    public function testCreateTranslationWithInvalidTranslationClass()
+    {
+        $this->obj->setTranslationClass('\\Missing\\LanguageMap');
+        $this->obj->createTranslation();
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     *
+     * @return void
+     */
+    public function testSetTranslationClass()
+    {
+        $ret = $this->obj->setTranslationClass('\\Missing\\LanguageMap');
+        $this->assertSame($ret, $this->obj);
+        $this->assertEquals('\\Missing\\LanguageMap', $this->obj->getTranslationClass());
+
+        $this->obj->setTranslationClass(5);
+    }
+
+    /**
+     * @return void
+     */
+    public function testInvalidArrayTranslation()
+    {
+        $method = $this->getMethod($this->obj, 'isValidTranslation');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invokeArgs($this->obj, [ [ 0 => 'Hello!' ] ]));
+        $this->assertFalse($method->invokeArgs($this->obj, [ [ 'hello' => 0 ] ]));
+    }
+
+    /**
+     * @link https://github.com/symfony/translation/blob/v3.2.3/Tests/TranslatorTest.php
+     *
+     * @return array
+     */
+    public function validTransTests()
+    {
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        return [
+            [ 'Charcoal est super !', 'Charcoal is great!', 'Charcoal est super !', [], 'fr', '' ],
+            [ 'Charcoal est awesome !', 'Charcoal is %what%!', 'Charcoal est %what% !', [ '%what%' => 'awesome' ], 'fr', '' ],
+            [ 'Charcoal is great!', [ 'en' => 'Charcoal is great!', 'fr' => 'Charcoal est super !'], 'Charcoal est super !', [], null, '' ],
+            [ 'Charcoal est super !', new Translation([ 'en' => 'Charcoal is great!', 'fr' => 'Charcoal est super !'], $this->localesManager()), 'Charcoal est super !', [], 'fr', '' ],
+            [ 'Charcoal est super !', new StringClass('Charcoal is great!'), 'Charcoal est super !', [], 'fr', '' ],
+        ];
+        // phpcs:enable
+    }
+
+    /**
+     * @return array
+     */
+    public function invalidTransTests()
+    {
+        return [
+            [ null ],
+            [ 0 ],
+            [ 1 ],
+            [ true ],
+            [ false ],
+            [ [] ],
+            [ [ 'foo', 'bar' ] ],
+            [ [ [ ] ] ],
+            [ '' ],
+        ];
+    }
+}

--- a/tests/Charcoal/Translator/LocalesConfigTest.php
+++ b/tests/Charcoal/Translator/LocalesConfigTest.php
@@ -48,8 +48,8 @@ class LocalesConfigTest extends AbstractTestCase
     {
         $langs = [
             'foo' => [
-                'locale'=>'foo-FOO'
-            ]
+                'locale' => 'foo-FOO',
+            ],
         ];
         $ret = $this->obj->setLanguages($langs);
         $this->assertSame($ret, $this->obj);
@@ -57,8 +57,8 @@ class LocalesConfigTest extends AbstractTestCase
 
         $langs = [
             'bar' => [
-                'locale'=>'bar-BAR'
-            ]
+                'locale' => 'bar-BAR',
+            ],
         ];
         $this->obj['languages'] = $langs;
         $this->assertEquals($langs, $this->obj['languages']);

--- a/tests/Charcoal/Translator/LocalesManagerTest.php
+++ b/tests/Charcoal/Translator/LocalesManagerTest.php
@@ -31,9 +31,9 @@ class LocalesManagerTest extends AbstractTestCase
             'locales' => [
                 'foo' => [],
                 'bar' => [],
-                'baz' => [ 'active' => false ]
+                'baz' => [ 'active' => false ],
             ],
-            'fallback_languages' => [ 'foo', 'bar' ]
+            'fallback_languages' => [ 'foo', 'bar' ],
         ]);
     }
 
@@ -46,9 +46,9 @@ class LocalesManagerTest extends AbstractTestCase
             'locales' => [
                 'foo' => [],
                 'bar' => [],
-                'baz' => [ 'active' => false ]
+                'baz' => [ 'active' => false ],
             ],
-            'default_language' => 'bar'
+            'default_language' => 'bar',
         ]);
         $this->assertEquals('bar', $this->obj->currentLocale());
         $this->assertEquals('bar', $this->obj->defaultLocale());
@@ -63,9 +63,9 @@ class LocalesManagerTest extends AbstractTestCase
     {
         $obj = new LocalesManager([
             'locales' => [
-                'foo' => []
+                'foo' => [],
             ],
-            'default_language' => false
+            'default_language' => false,
         ]);
     }
 
@@ -78,9 +78,9 @@ class LocalesManagerTest extends AbstractTestCase
     {
         $obj = new LocalesManager([
             'locales' => [
-                'foo' => []
+                'foo' => [],
             ],
-            'default_language' => 'bar'
+            'default_language' => 'bar',
         ]);
     }
 
@@ -92,7 +92,7 @@ class LocalesManagerTest extends AbstractTestCase
     public function testConstructorWithoutActiveLocales()
     {
         $obj = new LocalesManager([
-            'locales' => []
+            'locales' => [],
         ]);
     }
 
@@ -150,7 +150,7 @@ class LocalesManagerTest extends AbstractTestCase
                 'qux' => [ 'priority' => 1 ],
                 'xyz' => [ 'priority' => 0 ],
                 'zyx' => [ 'priority' => 0 ],
-            ]
+            ],
         ]);
     }
 

--- a/tests/Charcoal/Translator/Middleware/LanguageMiddlewareTest.php
+++ b/tests/Charcoal/Translator/Middleware/LanguageMiddlewareTest.php
@@ -68,7 +68,7 @@ class LanguageMiddlewareTest extends AbstractTestCase
         $container = $this->getContainer();
 
         $this->obj = $this->middlewareFactory([
-            'use_params' => true
+            'use_params' => true,
         ]);
     }
 
@@ -106,28 +106,28 @@ class LanguageMiddlewareTest extends AbstractTestCase
                 'locales'   => [
                     'languages' => [
                         'en' => [ 'locale' => 'en-US', 'locales' => [ 'en_US.UTF-8', 'en_US.utf8', 'en_US' ] ],
-                        'fr' => [ 'locale' => 'fr-FR' ]
+                        'fr' => [ 'locale' => 'fr-FR' ],
                     ],
                     'default_language'   => 'en',
-                    'fallback_languages' => [ 'en' ]
+                    'fallback_languages' => [ 'en' ],
                 ],
                 'translator' => [
                     'paths' => [
-                        '/Charcoal/Translator/Fixture/translations'
+                        '/Charcoal/Translator/Fixture/translations',
                     ],
                     'translations' => [
                         'messages' => [
                             'en' => [
-                                'foo' => 'FOO'
+                                'foo' => 'FOO',
                             ],
                             'fr' => [
-                                'foo' => 'OOF'
-                            ]
-                        ]
+                                'foo' => 'OOF',
+                            ],
+                        ],
                     ],
                     'auto_detect' => true,
-                    'debug' => false
-                ]
+                    'debug' => false,
+                ],
             ];
 
             $this->container->register(new TranslatorServiceProvider());
@@ -259,7 +259,7 @@ class LanguageMiddlewareTest extends AbstractTestCase
             'host_map'         => [
                 'en' => 'en.example.com',
                 'fr' => 'fr.example.com',
-            ]
+            ],
         ]);
 
         $uri = $this->createMock(UriInterface::class);
@@ -296,7 +296,7 @@ class LanguageMiddlewareTest extends AbstractTestCase
             'host_map'         => [
                 'en' => 'en.example.com',
                 'fr' => 'fr.example.com',
-            ]
+            ],
         ]);
 
         $uri = $this->createMock(UriInterface::class);
@@ -315,7 +315,7 @@ class LanguageMiddlewareTest extends AbstractTestCase
     public function testGetLanguageUseDefault()
     {
         $this->obj = $this->middlewareFactory([
-            'browser_language' => null
+            'browser_language' => null,
         ]);
 
         $request = $this->mockRequest();

--- a/tests/Charcoal/Translator/Script/TranslationParserScriptTest.php
+++ b/tests/Charcoal/Translator/Script/TranslationParserScriptTest.php
@@ -57,7 +57,7 @@ class TranslationParserScriptTest extends AbstractTestCase
             'logger'        => $this->container['logger'],
             'climate'       => $this->container['climate'],
             'model_factory' => $this->container['model/factory'],
-            'container'     => $this->container
+            'container'     => $this->container,
         ]);
     }
 

--- a/tests/Charcoal/Translator/ServiceProvider/TranslatorServiceProviderTest.php
+++ b/tests/Charcoal/Translator/ServiceProvider/TranslatorServiceProviderTest.php
@@ -71,19 +71,19 @@ class TranslatorServiceProviderTest extends AbstractTestCase
                 'translations' => [
                     'messages' => [
                         'en' => [
-                            'foo' => 'FOO'
+                            'foo' => 'FOO',
                         ],
                         'fr' => [
-                            'foo' => 'OOF'
-                        ]
-                    ]
+                            'foo' => 'OOF',
+                        ],
+                    ],
                 ],
                 'debug' => false,
                 'cache_dir' => 'translator_cache',
             ],
             'middlewares' => [
-                'charcoal/translator/middleware/language' => []
-            ]
+                'charcoal/translator/middleware/language' => [],
+            ],
         ];
 
         $this->container->register($this->obj);

--- a/tests/Charcoal/Translator/ServiceProvider/TranslatorServiceProviderTest.php
+++ b/tests/Charcoal/Translator/ServiceProvider/TranslatorServiceProviderTest.php
@@ -6,6 +6,7 @@ namespace Charcoal\Tests\Translation\ServiceProvider;
 use Pimple\Container;
 
 // From 'charcoal-translator'
+use Charcoal\Translator\Factory\TranslationFactoryInterface;
 use Charcoal\Translator\Middleware\LanguageMiddleware;
 use Charcoal\Translator\ServiceProvider\TranslatorServiceProvider;
 use Charcoal\Translator\LocalesManager;
@@ -116,6 +117,7 @@ class TranslatorServiceProviderTest extends AbstractTestCase
         $this->assertTrue(isset($this->container['locales/browser-language']));
         $this->assertTrue(isset($this->container['translator/message-selector']));
         $this->assertTrue(isset($this->container['translator']));
+        $this->assertTrue(isset($this->container['translation/factory']));
         $this->assertTrue(isset($this->container['middlewares/charcoal/translator/middleware/language']));
     }
 
@@ -231,6 +233,15 @@ class TranslatorServiceProviderTest extends AbstractTestCase
     {
         $translator = $this->container['translator'];
         $this->assertInstanceOf(Translator::class, $translator);
+    }
+
+    /**
+     * @return void
+     */
+    public function testTranslationFactory()
+    {
+        $factory = $this->container['translation/factory'];
+        $this->assertInstanceOf(TranslationFactoryInterface::class, $factory);
     }
 
     /**

--- a/tests/Charcoal/Translator/TranslationTest.php
+++ b/tests/Charcoal/Translator/TranslationTest.php
@@ -29,15 +29,14 @@ class TranslationTest extends AbstractTestCase
             $this->localesManager = new LocalesManager([
                 'locales' => [
                     'en' => [
-                        'locale' => 'en_US.UTF8'
+                        'locale' => 'en_US.UTF8',
                     ],
                     'fr' => [
-                        'locale' => 'fr_FR.UTF8'
-                    ]
+                        'locale' => 'fr_FR.UTF8',
+                    ],
                 ],
                 'default_language'   => 'en',
-                'fallback_languages' => [ 'en' ]
-
+                'fallback_languages' => [ 'en' ],
             ]);
         }
 

--- a/tests/Charcoal/Translator/TranslatorTest.php
+++ b/tests/Charcoal/Translator/TranslatorTest.php
@@ -7,9 +7,9 @@ use ReflectionClass;
 // From 'symfony/translation'
 use Symfony\Component\Translation\Formatter\MessageFormatter;
 use Symfony\Component\Translation\Loader\ArrayLoader;
-use Symfony\Component\Translation\MessageSelector;
 
 // From 'charcoal-translator'
+use Charcoal\Translator\Factory\TranslationFactory;
 use Charcoal\Translator\LocalesManager;
 use Charcoal\Translator\Translation;
 use Charcoal\Translator\Translator;
@@ -49,16 +49,17 @@ class TranslatorTest extends AbstractTestCase
      */
     public function setUp()
     {
-        $selector  = new MessageSelector();
-        $formatter = new MessageFormatter($selector);
+        $manager = $this->localesManager();
+        $factory = new TranslationFactory([
+            'manager' => $manager,
+        ]);
 
         $this->obj = new Translator([
-            'locale'            => 'en',
-            'cache_dir'         => null,
-            'debug'             => false,
-            'manager'           => $this->localesManager(),
-            'message_selector'  => $selector,
-            'message_formatter' => $formatter,
+            'locale'              => 'en',
+            'cache_dir'           => null,
+            'debug'               => false,
+            'manager'             => $manager,
+            'translation_factory' => $factory,
         ]);
 
         $this->obj->addLoader('array', new ArrayLoader());
@@ -112,51 +113,27 @@ class TranslatorTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testConstructorWithMessageSelector()
-    {
-        $selector   = new MessageSelector();
-        $translator = new Translator([
-            'locale'           => 'en',
-            'cache_dir'        => null,
-            'debug'            => false,
-            'manager'          => $this->localesManager(),
-            'message_selector' => $selector,
-        ]);
-
-        $this->assertSame($selector, $this->callMethod($translator, 'selector'));
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstructorWithoutMessageSelector()
-    {
-        $translator = new Translator([
-            'locale'           => 'en',
-            'cache_dir'        => null,
-            'debug'            => false,
-            'manager'          => $this->localesManager(),
-            'message_selector' => null,
-        ]);
-
-        $this->assertInstanceOf(MessageSelector::class, $this->callMethod($translator, 'selector'));
-    }
-
-    /**
-     * @return void
-     */
     public function testConstructorWithMessageFormatter()
     {
-        $formatter  = new MessageFormatter();
-        $translator = new Translator([
-            'locale'            => 'en',
-            'cache_dir'         => null,
-            'debug'             => false,
-            'manager'           => $this->localesManager(),
-            'message_formatter' => $formatter,
+        $manager    = $this->localesManager();
+        $formatter1 = new MessageFormatter();
+        $formatter2 = new MessageFormatter();
+        $factory    = new TranslationFactory([
+            'manager'           => $manager,
+            'message_formatter' => $formatter1,
         ]);
 
-        $this->assertSame($formatter, $this->callMethod($translator, 'formatter'));
+        $translator = new Translator([
+            'locale'              => 'en',
+            'cache_dir'           => null,
+            'debug'               => false,
+            'manager'             => $manager,
+            'translation_factory' => $factory,
+            'message_formatter'   => $formatter2,
+        ]);
+
+        $this->assertNotSame($formatter1, $this->callMethod($translator, 'getFormatter'));
+        $this->assertSame($formatter2, $this->callMethod($translator, 'getFormatter'));
     }
 
     /**
@@ -164,15 +141,23 @@ class TranslatorTest extends AbstractTestCase
      */
     public function testConstructorWithoutMessageFormatter()
     {
-        $translator = new Translator([
-            'locale'            => 'en',
-            'cache_dir'         => null,
-            'debug'             => false,
-            'manager'           => $this->localesManager(),
-            'message_formatter' => null,
+        $manager    = $this->localesManager();
+        $formatter1 = new MessageFormatter();
+        $factory    = new TranslationFactory([
+            'manager'           => $manager,
+            'message_formatter' => $formatter1,
         ]);
 
-        $this->assertInstanceOf(MessageFormatter::class, $this->callMethod($translator, 'formatter'));
+        $translator = new Translator([
+            'locale'              => 'en',
+            'cache_dir'           => null,
+            'debug'               => false,
+            'manager'             => $manager,
+            'translation_factory' => $factory,
+            'message_formatter'   => null,
+        ]);
+
+        $this->assertSame($formatter1, $this->callMethod($translator, 'getFormatter'));
     }
 
     /**
@@ -328,18 +313,6 @@ class TranslatorTest extends AbstractTestCase
     public function testAvailableLocales()
     {
         $this->assertEquals([ 'en', 'fr' ], $this->obj->availableLocales());
-    }
-
-    /**
-     * @return void
-     */
-    public function testInvalidArrayTranslation()
-    {
-        $method = $this->getMethod($this->obj, 'isValidTranslation');
-        $method->setAccessible(true);
-
-        $this->assertFalse($method->invokeArgs($this->obj, [ [ 0 => 'Hello!' ] ]));
-        $this->assertFalse($method->invokeArgs($this->obj, [ [ 'hello' => 0 ] ]));
     }
 
     /**

--- a/tests/Charcoal/Translator/TranslatorTest.php
+++ b/tests/Charcoal/Translator/TranslatorTest.php
@@ -95,15 +95,14 @@ class TranslatorTest extends AbstractTestCase
             $this->localesManager = new LocalesManager([
                 'locales' => [
                     'en' => [
-                        'locale' => 'en_US.UTF8'
+                        'locale' => 'en_US.UTF8',
                     ],
                     'fr' => [
-                        'locale' => 'fr_FR.UTF8'
-                    ]
+                        'locale' => 'fr_FR.UTF8',
+                    ],
                 ],
                 'default_language'   => 'en',
-                'fallback_languages' => [ 'en' ]
-
+                'fallback_languages' => [ 'en' ],
             ]);
         }
 
@@ -202,7 +201,7 @@ class TranslatorTest extends AbstractTestCase
 
         $ret = $this->obj->translation([
             'en' => 'Hello!',
-            'fr' => 'Bonjour!'
+            'fr' => 'Bonjour!',
         ]);
         $this->assertInstanceOf(Translation::class, $ret);
         $this->assertEquals('Hello!', (string)$ret);
@@ -266,7 +265,7 @@ class TranslatorTest extends AbstractTestCase
 
         $ret = $this->obj->translationChoice([
             'en' => 'There is one apple|There is %count% apples',
-            'fr' => 'Il y a %count% pomme|Il y a %count% pommes'
+            'fr' => 'Il y a %count% pomme|Il y a %count% pommes',
         ], 1);
         $this->assertInstanceOf(Translation::class, $ret);
         $this->assertEquals('There is one apple', (string)$ret);
@@ -414,7 +413,7 @@ class TranslatorTest extends AbstractTestCase
             [ [] ],
             [ [ 'foo', 'bar' ] ],
             [ [ [ ] ] ],
-            [ '' ]
+            [ '' ],
         ];
     }
 


### PR DESCRIPTION
The `TranslationFactory` is an alternative to the `Translator` for creating `Translation` objects without passing values through the message catalogues where a value might be accidentally translated.

Also, added support for empty `Translation` initialization. Previously, empty Translation objects could be created by passing an empty array.